### PR TITLE
Treat audio/mpeg like audio/mp3

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -14,7 +14,7 @@ $(function() {
     return true;
   };
 
-  var arrowTypes = ["audio/mp3", "audio/wav"];
+  var arrowTypes = ["audio/mpeg", "audio/mp3", "audio/wav"];
   var validateFileType = function(type) {
     var ret = false;
     for (var i=0; i < arrowTypes.length; i++) {
@@ -49,7 +49,11 @@ $(function() {
     $this.hide();
 
     var filename = 'heroku-' + new Date().getTime();
-    $.ajax('/upload?name=' + filename + "&type=" + file.type).done(function(data) {
+    var type = file.type;
+    if (file.type === 'audio/mpeg') {
+      type = 'audo/mp3';
+    }
+    $.ajax('/upload?name=' + filename + "&type=" + type).done(function(data) {
       console.log(data);
       var formdata = new FormData();
       for (key in data.fields) { formdata.append(key, data.fields[key]); }
@@ -70,7 +74,7 @@ $(function() {
           data: {
             name: filename,
             uri: data.url + "/upload/" + filename,
-            format: file.type.split("/")[1],
+            format: type.split("/")[1],
             lang: $("#lang").val(),
             number: $("#number").val()
           },


### PR DESCRIPTION
お世話になっています! 最近、ChromiumやFirefoxでファイルの選択やアップロード後に下記のようなエラーが見られるようになりました。

> audio/mpegのファイルタイプはサポートしておりません。可能なファイルタイプ: audio/mp3, audio/wav

![Screenshot 2020-05-11 11:07:27](https://user-images.githubusercontent.com/30968/81616858-d4745e00-93d3-11ea-88b8-f90bec7acdd2.png)

> ```
> Aws::TranscribeService::Errors::BadRequestException - 1 validation error detected: Value 'mpeg' at 'mediaFormat' failed to satisfy constraint: Member must satisfy enum value set: [flac, wav, mp3, mp4]:
> /app/vendor/bundle/ruby/2.6.0/gems/aws-sdk-core-3.86.0/lib/seahorse/client/plugins/raise_response_errors.rb:15:in `call'
> ```

とりあえず、このPRのような変更で`audio/mpeg`を`audio/mp3`として取り扱うことで期待どおりの動作をさせることができました。